### PR TITLE
feat: force commit type

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ alias ai-commit='docker run --network host -it --rm \
 - `--model`: Specify the AI model to use for generating the commit message (default is "mistral").
 - `--retries`, `-r`: Number of retries for invalid commit messages (default is 3).
 - `--quiet`: Run in silent mode (no logs). Only errors are printed to stderr.
-- `-t`: Select a commit type by writting the type next to the flag (feat, fix, refactor, docs, style...)
+- `--commitType`, `-t`: Select a commit type by writting the type next to the flag (feat, fix, refactor, docs, style...)
 
 ### Example
 ```sh

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ alias ai-commit='docker run --network host -it --rm \
 - `--model`: Specify the AI model to use for generating the commit message (default is "mistral").
 - `--retries`, `-r`: Number of retries for invalid commit messages (default is 3).
 - `--quiet`: Run in silent mode (no logs). Only errors are printed to stderr.
+- `-t`: Select a commit type by writting the type next to the flag (feat, fix, refactor, docs, style...)
 
 ### Example
 ```sh

--- a/internal/cmd/functions.go
+++ b/internal/cmd/functions.go
@@ -66,3 +66,19 @@ func generateCommitMessage(prompt, system, ollamaServer, model string, retries i
 
 	return cleanResult, err
 }
+
+// modifyCommitType modifies the commit type.
+func modifyCommitType(commitMessage string, commitType string) string {
+	parts := strings.SplitN(commitMessage, ":", 2)
+
+	if len(parts) > 1 {
+		scopeSplit := strings.SplitN(parts[0], "(", 2)
+		if len(scopeSplit) > 1 {
+			scope := strings.TrimRight(scopeSplit[1], ")")
+			return fmt.Sprintf("%s(%s):%s", commitType, scope, parts[1])
+		}
+		return fmt.Sprintf("%s:%s", commitType, parts[1])
+	}
+
+	return commitMessage
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -71,6 +71,12 @@ var rootCmd = &cobra.Command{
 			panic(err)
 		}
 
+		// If the commit type is not the default one, modify the commit type
+		if commitType != "none" {
+			commitMessage = modifyCommitType(commitMessage, commitType)
+			slog.Debug("Modified commit message with new commit type")
+		}
+
 		slog.Debug("Commit message", "message", commitMessage)
 
 		// If it's working in noop mode, print the commit message and exit

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -22,6 +22,7 @@ var (
 	retries      int
 	showVersion  bool
 	quiet        bool
+	commitType   string
 )
 
 var rootCmd = &cobra.Command{
@@ -104,6 +105,7 @@ func init() {
 	rootCmd.PersistentFlags().IntVarP(&retries, "retries", "r", *configure.Cfg.RetriesCommitMessage, "Set the number of retries for invalid commit messages")
 	rootCmd.PersistentFlags().BoolVarP(&showVersion, "version", "v", false, "Show the version of the application")
 	rootCmd.PersistentFlags().BoolVar(&quiet, "quiet", false, "Run in silent mode")
+	rootCmd.PersistentFlags().StringVarP(&commitType, "commitType", "t", "none", "Set the type of the commit message")
 }
 
 func Execute() {


### PR DESCRIPTION
This pull request introduces a new feature to specify the commit type when generating commit messages. The changes include updates to the command-line interface, modifications to the internal functions, and adjustments to the configuration.

Key changes:

### Command-line Interface Enhancements:
* Added a new flag `-t` to allow users to select a commit type (e.g., feat, fix, refactor, docs, style) in the `README.md` file.

### Internal Function Updates:
* Introduced the `modifyCommitType` function in `internal/cmd/functions.go` to modify the commit type in the generated commit message after this message has passed the conventional commit format check.

### Configuration Adjustments:
* Added a new variable `commitType` to store the commit type in `internal/cmd/root.go`.
* Updated the command initialization in `internal/cmd/root.go` to include the new `commitType` flag.
* Modified the commit message generation logic to apply the commit type if it is not the default value in `internal/cmd/root.go`.